### PR TITLE
Update handling for unit dimension failures

### DIFF
--- a/packages/front-end/components/Queries/RunQueriesButton.tsx
+++ b/packages/front-end/components/Queries/RunQueriesButton.tsx
@@ -57,10 +57,21 @@ export function getQueryStatus(
     if (queries[i].status === "running" || queries[i].status === "queued")
       running = true;
   }
-
-  if (numFailed > 0) status = "partially-succeeded";
+  
+  // Check for unit dimension failures
+  const hasUnitDimensionFailure = failedNames.some(name => 
+    name.includes("dim_unit_")
+  );
+  
   if (numFailed >= queries.length / 2) status = "failed";
-  if (running) status = "running";
+  // Unit dimension failures should be labeled as failed,  
+  else if (hasUnitDimensionFailure) {
+    status = "failed";
+  }
+  // Use standard behavior for other failures/running status
+  else if (numFailed > 0) status = "partially-succeeded";
+  else if (running) status = "running";
+  
   return { status, numFailed, failedNames };
 }
 


### PR DESCRIPTION
### Changes
GrowthBook's UI has an issue where, even when a user dimension query fails, the Results status continues to say "Running" .

_Status icon_
<img width="146" height="53" alt="image (3)" src="https://github.com/user-attachments/assets/177683fd-349a-426d-b763-9f5634897c2b" />

_Report results_
<img width="525" height="59" alt="image" src="https://github.com/user-attachments/assets/3e34d559-f54c-44d3-9744-6e3c767a58a1" />

The first query that runs after kicking off a report creates the `tmp_units` table, which tries to select the column  with an intentionally wrong dimension: 
```sql
           __dim_unit_dim_4r2... as ( -- Dimension (test_problematic_dimension)
                  -- Query issue here intentionally
                  SELECT
                    user_id,
                    column_that_does_not_exist AS value
                  FROM
                    `sample_table_name`
                ),
         ...
```

The subsequent queries pull from this `tmp_units` table and calculate the relevant metrics between experiment variations. The issue is that, after this first query fails, the metrics queries do not actually kick off and the `Running (22 hours)` button continues to tick upward, misleading users that GrowthBook is retrying queries and that they should continue to wait. Upon refreshing the tab in the browser, the "Running" status is reset, meaning this issue is specific to frontend. 

We've updated the status checks to specifically identify and prioritize unit dimension failures. This ensures that dimension query failures immediately update the UI rather than misleadingly showing "Running" when the process has effectively stopped, potentially wasting time or causing confusion. This change is more pertinent to pipeline mode but is good to include across the board.

### Testing
To test, we deployed to staging and verified behavior there first. As seen in the example below, after the dimension query failed, the `Running` icon was updated and no longer suggested queries were still running:

<img width="1376" height="353" alt="image (4)" src="https://github.com/user-attachments/assets/da55632c-2c2d-46b2-a1ee-b68900dae393" />

We also tested on a few other scenarios (report with working dimension, report with no dimension, general experiment metric update) to ensure no unintended consequences.